### PR TITLE
import time for sleep()

### DIFF
--- a/hidtools/backdoor/DuckEncoder.py
+++ b/hidtools/backdoor/DuckEncoder.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
-import sys
 import getopt
 import os
+import sys
+import time
 
 class DuckEncoder:
 	@staticmethod


### PR DESCRIPTION
Two other undefined names are NOT fixed....

flake8 testing of https://github.com/mame82/P4wnP1 on Python 2.7.13

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./hidtools/backdoor/DuckEncoder.py:190:43: F821 undefined name 'key_entry'
			print "Error: No keycode entry for " + key_entry
                                          ^

./hidtools/backdoor/DuckEncoder.py:392:17: F821 undefined name 'parseScriptLine'
						result += parseScriptLine(lastLine, keyProp, langProp)
                ^

./hidtools/backdoor/DuckEncoder.py:455:7: F821 undefined name 'time'
						time.sleep(d)
      ^
```