### PR TITLE
Allow connecting to existing AP

### DIFF
--- a/boot/boot_P4wnP1
+++ b/boot/boot_P4wnP1
@@ -51,6 +51,7 @@ source $wdir/boot/init_wifi.sh
 check_wifi
 if $WIFI; then
 	echo "P4wnP1: Seems WiFi module is present !"
+	# connect to accesspoint after some checks
 	# start ACCESS POINT if needed
 	if $WIFI_ACCESSPOINT; then
 		start_wifi_accesspoint

--- a/boot/boot_P4wnP1
+++ b/boot/boot_P4wnP1
@@ -52,9 +52,15 @@ check_wifi
 if $WIFI; then
 	echo "P4wnP1: Seems WiFi module is present !"
 	# connect to accesspoint after some checks
-	# start ACCESS POINT if needed
-	if $WIFI_ACCESSPOINT; then
+	if $CONNECT_TO_EXISTING_WIFI; then
+		# PASSTHROUGH ISNT WORKING FOR SOME REASON
+		# would be nice to get some help here
 		start_wifi_accesspoint
+	else
+		# start ACCESS POINT if needed
+		if $WIFI_ACCESSPOINT; then
+			start_wifi_accesspoint
+		fi
 	fi
 fi
 
@@ -74,7 +80,7 @@ if $USB_RNDIS || $USB_ECM; then
 fi
 
 # change hostname to make P4wnP1 resolveable on "name.local"
-if $WIFI || $USB_ETHERNET; then
+if $WIFI || $USB_ETHERNET || $CONNECT_TO_EXISTING_WIFI; then
 	hostname="MAME82-P4WNP1"
 
 	hostname $hostname

--- a/boot/boot_P4wnP1
+++ b/boot/boot_P4wnP1
@@ -55,7 +55,7 @@ if $WIFI; then
 	if $WIFI_ACCESSPOINT; then
 		echo "starting accesspoint"
 		start_wifi_accesspoint
-		if $CONNECT_TO_EXISTING_WIFI; then
+		if $EXISTING_AP; then
 			# PASSTHROUGH ISNT WORKING FOR SOME REASON
 			# would be nice to get some help here
 			echo "connecting to accesspoint"
@@ -80,7 +80,7 @@ if $USB_RNDIS || $USB_ECM; then
 fi
 
 # change hostname to make P4wnP1 resolveable on "name.local"
-if $WIFI || $USB_ETHERNET || $CONNECT_TO_EXISTING_WIFI; then
+if $WIFI || $USB_ETHERNET || $EXISTING_AP; then
 	hostname="MAME82-P4WNP1"
 
 	hostname $hostname

--- a/boot/boot_P4wnP1
+++ b/boot/boot_P4wnP1
@@ -55,7 +55,7 @@ if $WIFI; then
 	if $CONNECT_TO_EXISTING_WIFI; then
 		# PASSTHROUGH ISNT WORKING FOR SOME REASON
 		# would be nice to get some help here
-		start_wifi_accesspoint
+		connect_to_accesspoint
 	else
 		# start ACCESS POINT if needed
 		if $WIFI_ACCESSPOINT; then

--- a/boot/boot_P4wnP1
+++ b/boot/boot_P4wnP1
@@ -52,14 +52,14 @@ check_wifi
 if $WIFI; then
 	echo "P4wnP1: Seems WiFi module is present !"
 	# connect to accesspoint after some checks
-	if $CONNECT_TO_EXISTING_WIFI; then
-		# PASSTHROUGH ISNT WORKING FOR SOME REASON
-		# would be nice to get some help here
-		connect_to_accesspoint
-	else
-		# start ACCESS POINT if needed
-		if $WIFI_ACCESSPOINT; then
-			start_wifi_accesspoint
+	if $WIFI_ACCESSPOINT; then
+		echo "starting accesspoint"
+		start_wifi_accesspoint
+		if $CONNECT_TO_EXISTING_WIFI; then
+			# PASSTHROUGH ISNT WORKING FOR SOME REASON
+			# would be nice to get some help here
+			echo "connecting to accesspoint"
+			connect_to_accesspoint
 		fi
 	fi
 fi

--- a/boot/init_wifi.sh
+++ b/boot/init_wifi.sh
@@ -104,16 +104,16 @@ function connect_to_accesspoint()
 	sudo ifconfig wlan0 up
 	if [ $(sudo iwlist wlan0 scan | grep $EXISTING_AP_NAME) ]; then
 		# check if /etc/wpa_supplicant/wpa_supplicant.conf exists
-		printf "$EXISTING_AP_NAME was found"
+		printf "\"$EXISTING_AP_NAME\" was found\n"
 		if [ $(cat /etc/wpa_supplicant/wpa_supplicant.conf | grep $EXISTING_AP_NAME) ]; then
 			# only connect if its there. connect. if not open accesspoint
-			printf "entry was found, connecting..."
+			printf "entry was found, connecting...\n"
 			sudo wpa_supplicant -B -i wlan0 -c /etc/wpa_supplicant/wpa_supplicant.conf
 			sudo dhclient wlan0
 			#check if IP was obtained (to lazy to implement)
 		else
 			printf "\nNo entry for Accesspoint \"$EXISTING_AP_NAME\" found! creating one... "
-			if $EXISTING_AP_PSK; then
+			if [ $EXISTING_AP_PSK ]; then
 				$wdir/wifi/append_secure_wpa_conf.sh $EXISTING_AP_NAME $EXISTING_AP_PSK
 				printf "success! retrying...\n"
 				connect_to_accesspoint

--- a/boot/init_wifi.sh
+++ b/boot/init_wifi.sh
@@ -114,6 +114,8 @@ function connect_to_accesspoint()
 			if $EXISTING_AP_PSK; then
 				$wdir/wifi/append_secure_wpa_conf.sh $EXISTING_AP_NAME $EXISTING_AP_PSK
 				printf "success\n"
+				#try again
+				connect_to_accesspoint
 
 			else
 				printf "fail!\n PLEASE SPECIFY EXISTING_AP_PSK or use wifi/append_secure_wpa_conf.sh to generate an AP entry\n"

--- a/boot/init_wifi.sh
+++ b/boot/init_wifi.sh
@@ -98,3 +98,11 @@ function start_wifi_accesspoint()
 	generate_dnsmasq_wifi_conf
 	dnsmasq -C /tmp/dnsmasq_wifi.conf
 }
+
+function connect_to_accesspoint()
+{
+	sudo ifconfig wlan0 up
+	#CHECK FOR NETWORK: "sudo iwlist wlan0 scan"
+	#only connect if its there. connect. if not open accesspoint
+	sudo iwconfig wlan0 essid <ESSID> key s:<key>
+}

--- a/boot/init_wifi.sh
+++ b/boot/init_wifi.sh
@@ -98,32 +98,30 @@ function start_wifi_accesspoint()
 	generate_dnsmasq_wifi_conf
 	dnsmasq -C /tmp/dnsmasq_wifi.conf
 }
-
 function connect_to_accesspoint()
 {
+	#not sure how to setup dnsmasq and hostapd so this just gets run after the accesspoint was already started
 	sudo ifconfig wlan0 up
 	if [ $(sudo iwlist wlan0 scan | grep $EXISTING_AP_NAME) ]; then
 		# check if /etc/wpa_supplicant/wpa_supplicant.conf exists
+		printf "$EXISTING_AP_NAME was found"
 		if [ $(cat /etc/wpa_supplicant/wpa_supplicant.conf | grep $EXISTING_AP_NAME) ]; then
 			# only connect if its there. connect. if not open accesspoint
-			sudo wpa_supplicant -i wlan0 -c /etc/wpa_supplicant/wpa_supplicant.conf
+			printf "entry was found, connecting..."
+			sudo wpa_supplicant -B -i wlan0 -c /etc/wpa_supplicant/wpa_supplicant.conf
 			sudo dhclient wlan0
-			#check if IP was obtained
+			#check if IP was obtained (to lazy to implement)
 		else
 			printf "\nNo entry for Accesspoint \"$EXISTING_AP_NAME\" found! creating one... "
 			if $EXISTING_AP_PSK; then
 				$wdir/wifi/append_secure_wpa_conf.sh $EXISTING_AP_NAME $EXISTING_AP_PSK
-				printf "success\n"
-				#try again
+				printf "success! retrying...\n"
 				connect_to_accesspoint
-
 			else
 				printf "fail!\n PLEASE SPECIFY EXISTING_AP_PSK or use wifi/append_secure_wpa_conf.sh to generate an AP entry\n"
-				start_wifi_accesspoint
 			fi
 		fi
 	else
 		printf "\nNetwork \"$EXISTING_AP_NAME\" not found!\n"
-		start_wifi_accesspoint
 	fi
 }

--- a/install.sh
+++ b/install.sh
@@ -128,10 +128,11 @@ sudo cp conf/default_index.html /var/www/index.html
 sudo chmod a+r /var/www/index.html
 
 # create X MB image for USB storage
-image_size=$(df | awk '{if ($NF=="/"){print $4/1000*0.8}}')
+image_size=$(df | awk '{if ($NF=="/"){print int( $4/1000*0.8 )}}')
 echo "Creating "$image_size" MB image for USB Mass Storage emulation"
+echo "This might take some time"
 mkdir -p $wdir/USB_STORAGE
-dd if=/dev/zero of=$wdir/USB_STORAGE/image.bin bs=1M count=$image_size
+dd if=/dev/zero of=$wdir/USB_STORAGE/image.bin bs=1M count=$image_size status=progress
 mkdosfs $wdir/USB_STORAGE/image.bin
 
 # create folder to store loot found

--- a/install.sh
+++ b/install.sh
@@ -127,16 +127,15 @@ cp conf/default_Responder.conf Responder/Responder.conf
 sudo cp conf/default_index.html /var/www/index.html
 sudo chmod a+r /var/www/index.html
 
-
-# create 128 MB image for USB storage
-echo "Creating 128 MB image for USB Mass Storage emulation"
+# create X MB image for USB storage
+image_size=$(df | awk '{if ($NF=="/"){print $3/1000000*0.8}}')
+echo "Creating "$image_size" MB image for USB Mass Storage emulation"
 mkdir -p $wdir/USB_STORAGE
-dd if=/dev/zero of=$wdir/USB_STORAGE/image.bin bs=1M count=128
+dd if=/dev/zero of=$wdir/USB_STORAGE/image.bin bs=1M count=$image_size
 mkdosfs $wdir/USB_STORAGE/image.bin
 
 # create folder to store loot found
 mkdir -p $wdir/collected
-
 
 # create systemd service unit for P4wnP1 startup
 if [ ! -f /etc/systemd/system/P4wnP1.service ]; then

--- a/install.sh
+++ b/install.sh
@@ -128,11 +128,9 @@ sudo cp conf/default_index.html /var/www/index.html
 sudo chmod a+r /var/www/index.html
 
 # create X MB image for USB storage
-image_size=$(df | awk '{if ($NF=="/"){print int( $4/1000*0.8 )}}')
-echo "Creating "$image_size" MB image for USB Mass Storage emulation"
-echo "This might take some time"
+echo "Creating 128 MB image for USB Mass Storage emulation"
 mkdir -p $wdir/USB_STORAGE
-dd if=/dev/zero of=$wdir/USB_STORAGE/image.bin bs=1M count=$image_size status=progress
+dd if=/dev/zero of=$wdir/USB_STORAGE/image.bin bs=1M count=128
 mkdosfs $wdir/USB_STORAGE/image.bin
 
 # create folder to store loot found

--- a/install.sh
+++ b/install.sh
@@ -128,7 +128,7 @@ sudo cp conf/default_index.html /var/www/index.html
 sudo chmod a+r /var/www/index.html
 
 # create X MB image for USB storage
-image_size=$(df | awk '{if ($NF=="/"){print $3/1000000*0.8}}')
+image_size=$(df | awk '{if ($NF=="/"){print $4/1000*0.8}}')
 echo "Creating "$image_size" MB image for USB Mass Storage emulation"
 mkdir -p $wdir/USB_STORAGE
 dd if=/dev/zero of=$wdir/USB_STORAGE/image.bin bs=1M count=$image_size

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,9 +46,9 @@ WIFI_ACCESSPOINT_DHCP_RANGE="172.24.0.2,172.24.0.100" # DHCP Server IP Range
 # connect to normal wpa2 network
 # ===============================
 
-WIFI_ACCESSPOINT=true
-EXISTING_AP_NAME="Stinktier"
-EXISTING_AP_PSK="Rotohrmunki1008" #not needed when entry already present in wpa_supplicant.conf (use wifi/append_secure_wpa_conf.sh to add entrys)
+EXISTING_AP=false
+EXISTING_AP_NAME=""
+EXISTING_AP_PSK="" #not needed when entry already present in wpa_supplicant.conf (use wifi/append_secure_wpa_conf.sh to add entrys)
 
 
 # =====================

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,15 @@ WIFI_ACCESSPOINT_IP="172.24.0.1" # IP used by P4wnP1
 WIFI_ACCESSPOINT_NETMASK="255.255.255.0"
 WIFI_ACCESSPOINT_DHCP_RANGE="172.24.0.2,172.24.0.100" # DHCP Server IP Range
 
+# ===============================
+# connect to normal wpa2 network
+# ===============================
+
+WIFI_ACCESSPOINT=true
+EXISTING_AP_NAME="Stinktier"
+EXISTING_AP_PSK="Rotohrmunki1008" #not needed when entry already present in wpa_supplicant.conf (use wifi/append_secure_wpa_conf.sh to add entrys)
+
+
 # =====================
 # Keyboard config
 # =====================

--- a/wifi/append_secure_wpa_conf.sh
+++ b/wifi/append_secure_wpa_conf.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+# basic tool that takes SSID and Passphrase, generates the psk, strips the cleartext password and appends to /etc/wpa_supplicant/wpa_supplicant.conf
+
+conf_dir=/etc/wpa_supplicant/wpa_supplicant.conf
+
+if [ $# -eq 2 ]; then
+	echo >> $conf_dir
+	wpa_passphrase $1 $2 | sed '/^\s*#/ d' >> $conf_dir
+	printf "\nsuccessfully appended to config\n\n"
+else
+	printf "\nUsage:\n$0 <ssid> <passphrase>\n\n"
+fi


### PR DESCRIPTION
This is a little addon that uses wpa_supplicant to connect to already existing APs for greater range, more flexibility and more importantly ethernet access.
Sadly I don't know how to share this connection with the victim pc and every guide I tried to follow failed at `sudo iptables -t filter -A POSTROUTING -o usb0 -j MASQUERADE
iptables: No chain/target/match by that name.`
