### PR TITLE
Make sure directory exists before generating AutoSSH key

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -207,6 +207,9 @@ sudo rpi-update
 
 echo "Generating keypair for use with AutoSSH..."
 source $wdir/setup.cfg
+
+mkdir -p -- "$(dirname -- "$AUTOSSH_PRIVATE_KEY")"
+
 ssh-keygen -q -N "" -C "P4wnP1" -f $AUTOSSH_PRIVATE_KEY && SUCCESS=true
 if $SUCCESS; then
         echo "... keys created"


### PR DESCRIPTION
On a fresh install the directory: `$wdir/ssh/keys` doesn't exist so the key for AutoSSH isn't generated.