### PR TITLE
Stops dnsmasq from annoucing default gateway routes incorrectly

### DIFF
--- a/boot/init_usb_ethernet.sh
+++ b/boot/init_usb_ethernet.sh
@@ -163,6 +163,14 @@ function create_DHCP_config()
 				# routes static (route 128.0.0.1 to 255.255.255.254 through our device)
 				dhcp-option=249,0.0.0.0/1,$IF_IP,128.0.0.0/1,$IF_IP
 			EOF
+               else
+                       cat <<- EOF >> /tmp/dnsmasq_usb_eth.conf
+                               # router disable DHCP gateway announcment
+                               dhcp-option=3
+
+                               # disable DNS settings
+                               dhcp-option=6
+                       EOF
 		fi
 
 		if $WPAD_ENTRY; then


### PR DESCRIPTION
Following on from your link: https://superuser.com/questions/306121/i-dont-want-my-dhcp-to-be-a-default-gateway

This seems to fix the issue, DHCP still hands out addresses but not longer forces a default route without "ROUTE_SPOOF"

Thanks