### PR TITLE
Update Win10 LockPicker to support usernames with spaces.

### DIFF
--- a/payloads/Win10_LockPicker.txt
+++ b/payloads/Win10_LockPicker.txt
@@ -132,7 +132,7 @@ function check_for_hash()
 function get_hash()
 {
 	# exclude hashes for "SMB\"
-	sqlite3 -line $wdir/Responder/Responder.db "select fullhash from responder where not user='SMB\'" | cut -d " " -f3
+	sqlite3 $wdir/Responder/Responder.db "select fullhash from responder where not user='SMB\' limit 1"
 }
 
 function kill_responder()


### PR DESCRIPTION
I know you are not working on the Win10 Lockpicker now that it has been patched, but since we all know know that not everyone patches in a timely manner *cough*Equifax*cough*, I patched the bug where retrieving the hash for a user with a space in their username failed.