### PR TITLE
Don't forget self in hidtools/backdoor/Channel.py

### DIFF
--- a/hidtools/backdoor/Channel.py
+++ b/hidtools/backdoor/Channel.py
@@ -253,7 +253,7 @@ class StreamChannel(Channel):
         self.__position = value
 
     @property
-    def ReadTimeout():
+    def ReadTimeout(self):
         return self.__read_timeout
     
     @ReadTimeout.setter
@@ -261,7 +261,7 @@ class StreamChannel(Channel):
         self.__read_timeout = value
         
     @property
-    def WriteTimeout():
+    def WriteTimeout(self):
         return self.__write_timeout
     
     @WriteTimeout.setter


### PR DESCRIPTION
flake8 testing of https://github.com/mame82/P4wnP1 on Python 2.7.14

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./hidtools/backdoor/Channel.py:257:16: F821 undefined name 'self'
        return self.__read_timeout
               ^
./hidtools/backdoor/Channel.py:265:16: F821 undefined name 'self'
        return self.__write_timeout
               ^
2     F821 undefined name 'self'
2
```