### PR TITLE
Option to enable dnsmasq default gateway without adding 0.0.0.0/1 and 128.0.0.0/1 routes

### DIFF
--- a/boot/init_usb_ethernet.sh
+++ b/boot/init_usb_ethernet.sh
@@ -146,7 +146,7 @@ function create_DHCP_config()
 
 		EOF
 
-		if $ROUTE_SPOOF; then
+		if $DEFAULT_GATEWAY || $ROUTE_SPOOF; then  # ROUTE_SPOOF implicitly enables DEFAULT_GATEWAY
 			cat <<- EOF >> /tmp/dnsmasq_usb_eth.conf
 				# router
 				dhcp-option=3,$IF_IP
@@ -158,11 +158,15 @@ function create_DHCP_config()
 				dhcp-option=44,$IF_IP
 				dhcp-option=45,$IF_IP
 
-				# routes static (route 0.0.0.1 to 127.255.255.254 through our device)
-				dhcp-option=121,0.0.0.0/1,$IF_IP,128.0.0.0/1,$IF_IP
-				# routes static (route 128.0.0.1 to 255.255.255.254 through our device)
-				dhcp-option=249,0.0.0.0/1,$IF_IP,128.0.0.0/1,$IF_IP
 			EOF
+			if $ROUTE_SPOOF; then
+				cat <<- EOF >> /tmp/dnsmasq_usb_eth.conf
+					# routes static (route 0.0.0.1 to 127.255.255.254 through our device)
+					dhcp-option=121,0.0.0.0/1,$IF_IP,128.0.0.0/1,$IF_IP
+					# routes static (route 128.0.0.1 to 255.255.255.254 through our device)
+					dhcp-option=249,0.0.0.0/1,$IF_IP,128.0.0.0/1,$IF_IP
+			EOF
+			fi
 		else
 			cat <<- EOF >> /tmp/dnsmasq_usb_eth.conf
 				# router disable DHCP gateway announcment

--- a/payloads/net_over_wifi.txt
+++ b/payloads/net_over_wifi.txt
@@ -1,0 +1,82 @@
+#    This file is part of P4wnP1.
+#
+#    Copyright (c) 2017, Marcus Mengs. 
+#
+#    P4wnP1 is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    P4wnP1 is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with P4wnP1.  If not, see <http://www.gnu.org/licenses/>.
+
+
+
+# P4wnP1 payload to send all internet trafic over WI-Fi.
+# ==========================
+
+# =============================
+# USB setup
+# =============================
+# Make sure to change USB_PID if you enable different USB functionality in order
+# to force Windows to enumerate the device again
+USB_VID="0x1d6b"        # Vendor ID
+USB_PID="0x0106"        # Product ID
+
+USE_ECM=true            # if true CDC ECM will be enabled (Ethernet over USB for Windows)
+USE_RNDIS=true          # if true RNDIS will be enabled (Ethernet over USB for macOS/Linux)
+USE_HID=false            # if true HID keyboard will be enabled (USB keyboard attacks)
+USE_UMS=false           # if true USB Mass Storage will be enabled
+USE_RAWHID=false         # if true HID raw device will be enabled (used by HID covert channel payloads)
+
+
+# ==========================
+# Network and DHCP options for Ethernet over USB
+# ==========================
+
+# We choose an IP with a very small subnet (see comments in README.rst)
+IF_IP="192.168.0.1" # IP used by P4wnP1
+IF_MASK="255.255.255.252" 
+IF_DHCP_RANGE="192.168.0.2,192.168.0.3" # DHCP Server IP Range
+DEFAULT_GATEWAY=true
+
+# ============================
+# Network and DHCP options for WiFi (Pi Zero W with "wlan0" present)
+# ============================
+WIFI_ACCESSPOINT=false
+
+# ============================
+# WiFi Client Settings
+# ============================
+
+WIFI_CLIENT=true 	# enables connecting to existing WiFi (currently only WPA2 PSK)
+WIFI_CLIENT_SSID="network" # name of target network
+WIFI_CLIENT_PSK="super_secret_password" # passphrase for target network
+
+function onNetworkUp()
+{
+	sysctl -w net.ipv4.ip_forward=1
+	iptables -t nat -A POSTROUTING -o wlan0 -j MASQUERADE 
+	led_blink 255 # set LED to solid on
+}
+
+function onTargetGotIP()
+{
+}
+
+function onBootFinished()
+{
+}
+
+function onLogin()
+{
+}
+
+function onKeyboardUp()
+{
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ IF_IP="172.16.0.1" # IP used by P4wnP1
 IF_MASK="255.255.255.252"
 IF_DHCP_RANGE="172.16.0.2,172.16.0.2" # DHCP Server IP Range
 
+DEFAULT_GATEWAY=false # announce itself as a default gateway
 ROUTE_SPOOF=false # set two static routes on target to cover whole IPv4 range
 WPAD_ENTRY=false # provide a WPAD entry via DHCP pointing to responder
 


### PR DESCRIPTION
Currently, it is possible to enable default gateway in dnsmasq and add two routes by using `ROUTE_SPOOF` option, or to disable default gateway completely. I feel that there should be an option to define a default gateway and not to push out any other routes. That's what this pull request is about.

I moved this part of a functionality out of `ROUTE_SPOOF` to a `DEFAULT_GATEWAY` option.

At the same time it remains backward compatible. If anyone enables `ROUTE_SPOOF` it also pushes default gateway.

Also, I attached a payload `net_over_wifi.txt`. It doesn't do anything besides forwarding all the trafic through P4wnP1 and WiFi. It's not hard to add some meaningful network MitM attacks on top of it.