### PR TITLE
Remove default WiFi configuration in network_only payload

### DIFF
--- a/payloads/network_only.txt
+++ b/payloads/network_only.txt
@@ -42,7 +42,7 @@ ROUTE_SPOOF=false
 WIFI_ACCESSPOINT=true # enable wifi access point, P4wnP1 will be reachable via IP configured in setup.cfg (WIFI_ACCESSPOINT_IP)
 # Note that any 'WIFI_' settings found in setup.cfg can be overridden for this payload by placing them here.
 
-BLUETOOTH_NAP=true # enable bluetooth NAP, P4wnP1 will be rechable via IP configured in setup.cfg (BLUETOOTH_NAP_IP)
+BLUETOOTH_NAP=true # enable bluetooth NAP, P4wnP1 will be reachable via IP configured in setup.cfg (BLUETOOTH_NAP_IP)
 
 
 # The AutoSSH section enables a SSH reachback to a custom external SSH server


### PR DESCRIPTION
Currently, the network_only payload overrides setup.cfg for WiFi options. Though an excellent demonstration of the payload priority, it has repeatedly been a source of issues (#234, #205, #186, #156, #98, #96) and simply isn't user friendly.

Given that network_only payload is the default selected payload and will most likely be used when doing initial configuration, I suggest we remove the override and replace it with a message indicating the ability to make the changes if the user wishes. Though this will not solve the issue of users not knowing about the payload setting priority (as the user will still encounter it when eventually switching to another payload), it at least delays it, giving the user a better chance of coming across it themselves before submitting an issue. Furthermore, it makes network_only a better payload for use in basic setup.

More obvious documentation of the payload priority is of course needed as well, this is just a first step.