### PR TITLE
Add support for WPA2 Enterprise networks in WIFI_CLIENT

### DIFF
--- a/boot/init_wifi.sh
+++ b/boot/init_wifi.sh
@@ -215,6 +215,25 @@ function generate_wpa_entry()
 	res=$(wpa_passphrase "$1" "$2") && echo "$res" | grep -v -e "#psk"
 }
 
+function generate_wpa_enterprise_entry()
+{
+
+	#wpa_passphrase $1 $2 | grep -v -e "#psk"
+	# output result only if valid password was used (8..63 characters)
+	res="network={
+    	ssid=\"$1\"
+		scan_ssid=1
+    	key_mgmt=WPA-EAP
+    	group=CCMP TKIP
+    	eap=PEAP
+    	identity=\"$2\"
+    	password=\"$3\"
+    	phase1=\"peapver=0\"
+    	phase2=\"MSCHAPV2\"
+	}"
+	echo $res;
+}
+
 function scan_for_essid()
 {
 	# scan for given ESSID, needs root privs (sudo appended to allow running from user pi if needed)
@@ -228,6 +247,9 @@ function scan_for_essid()
 			# check for PSK CCMP
 			if (echo "$scanres" | grep -q -e "CCMP" && echo "$scanres" | grep -q -e "PSK"); then
 				echo "WPA2_PSK" # confirm WPA2 usage
+			# check for WPA2 enterprise
+			elif (echo "$scanres" | grep -q -e "CCMP" && echo "$scanres" | grep -q -e "802.1x"); then
+				echo "WPA2_802"
 			else
 				echo "WPA2 no CCMP PSK"
 			fi
@@ -252,9 +274,13 @@ function generate_wpa_supplicant_conf()
 	# if
 	#	WIFI_CLIENT_STORE_NETWORK == false
 	# delete the network entry, to overwrite the old entry in next step (but don't store it later on)
-
-	generate_wpa_entry "$1" "$2" > /tmp/current_wpa.conf
-	sudo bash -c 'cat /tmp/current_wpa.conf >> /tmp/wpa_supplicant.conf'
+	if [ $3 == "WPA_PSK" ]; then
+		generate_wpa_entry "$1" "$2" > /tmp/current_wpa.conf
+		sudo bash -c 'cat /tmp/current_wpa.conf >> /tmp/wpa_supplicant.conf'
+	else
+		generate_wpa_enterprise_entry "$1" "$2" "$3" > /tmp/current_wpa.conf
+		sudo bash -c 'cat /tmp/current_wpa.conf >> /tmp/wpa_supplicant.conf'
+	fi
 
 	# ToDo: store the new network back to persistent config
 	# if
@@ -284,10 +310,16 @@ function start_wifi_client()
 		if [ "$res" == "WPA2_PSK" ]; then
 			echo "Network $WIFI_CLIENT_SSID found"
 			echo "... creating config"
-			generate_wpa_supplicant_conf "$WIFI_CLIENT_SSID" "$WIFI_CLIENT_PSK"
+			generate_wpa_supplicant_conf "$WIFI_CLIENT_SSID" "$WIFI_CLIENT_PSK" "$res" # Pass wifi auth type
 			echo "... connecting ..."
 			start_wpa_supplicant
 			return 0
+		elif [ "$res" == "WPA2_802" ]; then
+			echo "Network $WIFI_CLIENT_SSID found"
+			echo "... creating config"
+			generate_wpa_supplicant_conf "$WIFI_CLIENT_SSID" "$WIFI_CLIENT_USERNAME" "$WIFI_CLIENT_PASSWORD" "$res" # Pass wifi credentials instead of PSK
+			echo "... connecting ..."
+			start_wpa_supplicant
 		else
 			echo "Network $WIFI_CLIENT_SSID not found"
 			return 1 # indicate error

--- a/boot/init_wifi.sh
+++ b/boot/init_wifi.sh
@@ -220,7 +220,7 @@ function generate_wpa_enterprise_entry()
 
 	#wpa_passphrase $1 $2 | grep -v -e "#psk"
 	# output result only if valid password was used (8..63 characters)
-	res="network={
+	echo "network={
     	ssid=\"$1\"
 		scan_ssid=1
     	key_mgmt=WPA-EAP
@@ -230,8 +230,8 @@ function generate_wpa_enterprise_entry()
     	password=\"$3\"
     	phase1=\"peapver=0\"
     	phase2=\"MSCHAPV2\"
-	}"
-	echo $res;
+}"
+
 }
 
 function scan_for_essid()

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,6 +75,8 @@ WIFI_CLIENT_SSID="Accespoint Name" # name of target network
 WIFI_CLIENT_PSK="AccessPoint password" # passphrase for target network
 WIFI_CLIENT_STORE_NETWORK=false # unused right now, should be used to store known networks, but priority has to be given if multiple known networks are present
 WIFI_CLIENT_OVERWRITE_PSK=true # unused right now, in case the network WIFI_CLIENT_STORE_NETWORK is set an existing PSK gets overwritten
+WIFI_CLIENT_USERNAME="Anon" # Username for WPA2 Enterprise
+WIFI_CLIENT_PASSWORD="Some password" # Password for WPA2 Enterprise
 
 # ==================================
 # Keyboard settings for HID keyboard


### PR DESCRIPTION
Added two new variables to `setup.cfg`: `WIFI_CLIENT_USERNAME` and `WIFI_CLIENT_PASSWORD`. 

The `init_wifi.sh` script auto-detects when the network specified in `WIFI_CLIENT_SSID` is an enterprise network.